### PR TITLE
feat(label): removed mandatory for input and textarea

### DIFF
--- a/src/components/Input/Input.stories.ts
+++ b/src/components/Input/Input.stories.ts
@@ -24,5 +24,27 @@ export const Default: Story = {
     label: 'E-mail',
     description: 'We will never share your email with anyone else.',
     inputSize: 'lg',
+    className: 'w-96',
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    ...Default.args,
+    errorMessage: 'This field is required.',
+  },
+};
+
+export const WithoutLabel: Story = {
+  args: {
+    ...Default.args,
+    label: undefined,
+  },
+};
+
+export const WithoutDescription: Story = {
+  args: {
+    ...Default.args,
+    description: undefined,
   },
 };

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -22,7 +22,7 @@ const inputVariants = cva('block w-full rounded-md border-0', {
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement>,
     VariantProps<typeof inputVariants> {
-  label: string;
+  label?: string;
   description?: string;
   errorMessage?: string;
   inputSize?: 'xs' | 'sm' | 'lg' | 'xl' | '2xl';
@@ -36,12 +36,14 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
 
   return (
     <div className="w-full">
-      <label
-        htmlFor="email"
-        className="block text-sm font-medium font-AvenirNext leading-6 text-gray-900 mb-2"
-      >
-        {label}
-      </label>
+      {label && (
+        <label
+          htmlFor="email"
+          className="block text-sm font-medium font-AvenirNext leading-6 text-gray-900 mb-2"
+        >
+          {label}
+        </label>
+      )}
       <input
         ref={ref}
         id="email"

--- a/src/components/TextArea/TextArea.stories.ts
+++ b/src/components/TextArea/TextArea.stories.ts
@@ -24,5 +24,27 @@ export const Default: Story = {
     label: 'Description',
     description: 'A description of the thing you are describing',
     textareaSize: 'xl',
+    className: 'w-96',
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    ...Default.args,
+    errorMessage: 'This field is required.',
+  },
+};
+
+export const WithoutLabel: Story = {
+  args: {
+    ...Default.args,
+    label: undefined,
+  },
+};
+
+export const WithoutDescription: Story = {
+  args: {
+    ...Default.args,
+    description: undefined,
   },
 };

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -25,7 +25,7 @@ const textareaVariants = cva(
 export interface TextAreaProps
   extends React.InputHTMLAttributes<HTMLTextAreaElement>,
     VariantProps<typeof textareaVariants> {
-  label: string;
+  label?: string;
   description?: string;
   errorMessage?: string;
   textareaSize?: 'xs' | 'sm' | 'lg' | 'xl' | '2xl';
@@ -46,12 +46,14 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
 
     return (
       <div className="w-full">
-        <label
-          htmlFor="text"
-          className="block text-sm font-medium font-AvenirNext leading-6 text-gray-900 mb-2"
-        >
-          {label}
-        </label>
+        {label && (
+          <label
+            htmlFor="text"
+            className="block text-sm font-medium font-AvenirNext leading-6 text-gray-900 mb-2"
+          >
+            {label}
+          </label>
+        )}
         <textarea
           ref={ref}
           id="textarea"


### PR DESCRIPTION
We are removing mandatory `label` for `Input` and `TextArea` components.
We are now able to use them without putting a `label`.

**EX:**
```typescript
import { Input } from '@tastit/ui-kit';

export default function Page() {
  return (
    <div>
      <Input placeholder="Rechercher" />
    </div>
  );
}
``` 